### PR TITLE
Add MonthStart/MonthEnd and NextWeekday/PreviousWeekday funcs

### DIFF
--- a/rawdate/rawdate.go
+++ b/rawdate/rawdate.go
@@ -151,3 +151,14 @@ func (r RawDate) AddDate(years, months, days int) RawDate {
 	t := r.Time(time.UTC).AddDate(years, months, days)
 	return MustNew(t.Year(), t.Month(), t.Day())
 }
+
+// MonthStart returns a new RawDate that represents the first day of the month for the given RawDate.
+func (r RawDate) MonthStart() RawDate {
+	return MustNew(r.Year(), r.Month(), 1)
+}
+
+// MonthEnd returns a new RawDate that represents the last day of the month for the given RawDate.
+func (r RawDate) MonthEnd() RawDate {
+	daysInMonth := time.Date(r.Year(), r.Month()+1, 0, 0, 0, 0, 0, time.UTC).Day()
+	return MustNew(r.Year(), r.Month(), daysInMonth)
+}

--- a/rawdate/rawdate.go
+++ b/rawdate/rawdate.go
@@ -162,3 +162,35 @@ func (r RawDate) MonthEnd() RawDate {
 	daysInMonth := time.Date(r.Year(), r.Month()+1, 0, 0, 0, 0, 0, time.UTC).Day()
 	return MustNew(r.Year(), r.Month(), daysInMonth)
 }
+
+// NextWeekday returns the next date that falls on the given weekday.
+// If orToday is true and the given weekday is today, it returns the current date.
+func (r RawDate) NextWeekday(weekday time.Weekday, orToday bool) RawDate {
+	if orToday && r.Weekday() == weekday {
+		return r
+	}
+
+	difference := int(weekday - r.Weekday())
+	if difference <= 0 {
+		difference += 7
+	}
+
+	return r.AddDate(0, 0, difference)
+}
+
+// PreviousWeekday returns the previous date that falls on the given weekday.
+// If orToday is true and the given weekday is today, it returns the current date.
+func (r RawDate) PreviousWeekday(weekday time.Weekday, orToday bool) RawDate {
+	if orToday && r.Weekday() == weekday {
+		return r
+	}
+
+	var difference int
+	if r.Weekday() > weekday {
+		difference = int(r.Weekday() - weekday)
+	} else {
+		difference = int(r.Weekday() - weekday + 7)
+	}
+
+	return r.AddDate(0, 0, -difference)
+}

--- a/rawdate/rawdate.go
+++ b/rawdate/rawdate.go
@@ -166,11 +166,12 @@ func (r RawDate) MonthEnd() RawDate {
 // NextWeekday returns the next date that falls on the given weekday.
 // If orToday is true and the given weekday is today, it returns the current date.
 func (r RawDate) NextWeekday(weekday time.Weekday, orToday bool) RawDate {
-	if orToday && r.Weekday() == weekday {
+	wd := r.Weekday()
+	if orToday && wd == weekday {
 		return r
 	}
 
-	difference := int(weekday - r.Weekday())
+	difference := int(weekday - wd)
 	if difference <= 0 {
 		difference += 7
 	}
@@ -181,15 +182,16 @@ func (r RawDate) NextWeekday(weekday time.Weekday, orToday bool) RawDate {
 // PreviousWeekday returns the previous date that falls on the given weekday.
 // If orToday is true and the given weekday is today, it returns the current date.
 func (r RawDate) PreviousWeekday(weekday time.Weekday, orToday bool) RawDate {
-	if orToday && r.Weekday() == weekday {
+	wd := r.Weekday()
+	if orToday && wd == weekday {
 		return r
 	}
 
 	var difference int
 	if r.Weekday() > weekday {
-		difference = int(r.Weekday() - weekday)
+		difference = int(wd - weekday)
 	} else {
-		difference = int(r.Weekday() - weekday + 7)
+		difference = int(wd - weekday + 7)
 	}
 
 	return r.AddDate(0, 0, -difference)

--- a/rawdate/rawdate_test.go
+++ b/rawdate/rawdate_test.go
@@ -316,9 +316,9 @@ func TestRawDate_MonthStart(t *testing.T) {
 
 func TestRawDate_MonthEnd(t *testing.T) {
 	tests := []struct {
-		name   string
-		fields rawdate.RawDate
-		want   rawdate.RawDate
+		name string
+		base rawdate.RawDate
+		want rawdate.RawDate
 	}{
 		{"march 2024", rawdate.MustNew(2024, time.March, 11), rawdate.MustNew(2024, time.March, 31)},
 		{"april 2024", rawdate.MustNew(2024, time.April, 11), rawdate.MustNew(2024, time.April, 30)},
@@ -327,13 +327,63 @@ func TestRawDate_MonthEnd(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := rawdate.RawDate{
-				Year0:  tt.fields.Year0,
-				Month0: tt.fields.Month0,
-				Day0:   tt.fields.Day0,
-			}
-			if got := r.MonthEnd(); !reflect.DeepEqual(got, tt.want) {
+			if got := tt.base.MonthEnd(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("MonthEnd() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRawDate_NextWeekday(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    rawdate.RawDate
+		weekday time.Weekday
+		orToday bool
+		want    rawdate.RawDate
+	}{
+		{"1. march 2024 false", rawdate.MustNew(2024, time.March, 1), time.Monday, false, rawdate.MustNew(2024, time.March, 4)},
+		{"1. march 2024 false", rawdate.MustNew(2024, time.March, 1), time.Friday, false, rawdate.MustNew(2024, time.March, 8)},
+		{"1. march 2024 true", rawdate.MustNew(2024, time.March, 1), time.Friday, true, rawdate.MustNew(2024, time.March, 1)},
+		{"15. april 2024 true", rawdate.MustNew(2024, time.April, 15), time.Sunday, true, rawdate.MustNew(2024, time.April, 21)},
+		{"15. april 2024 false", rawdate.MustNew(2024, time.April, 15), time.Sunday, false, rawdate.MustNew(2024, time.April, 21)},
+		{"16. april 2024 true", rawdate.MustNew(2024, time.April, 15), time.Thursday, true, rawdate.MustNew(2024, time.April, 18)},
+		{"16. april 2024 false", rawdate.MustNew(2024, time.April, 15), time.Thursday, false, rawdate.MustNew(2024, time.April, 18)},
+		{"21. april 2024 true", rawdate.MustNew(2024, time.April, 21), time.Friday, true, rawdate.MustNew(2024, time.April, 26)},
+		{"21. april 2024 false", rawdate.MustNew(2024, time.April, 21), time.Friday, false, rawdate.MustNew(2024, time.April, 26)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.base.NextWeekday(tt.weekday, tt.orToday); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NextWeekday() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRawDate_PreviousWeekday(t *testing.T) {
+	tests := []struct {
+		name    string
+		base    rawdate.RawDate
+		weekday time.Weekday
+		orToday bool
+		want    rawdate.RawDate
+	}{
+		{"1. march 2024 false", rawdate.MustNew(2024, time.March, 1), time.Monday, false, rawdate.MustNew(2024, time.February, 26)},
+		{"1. march 2023 false", rawdate.MustNew(2023, time.March, 1), time.Friday, false, rawdate.MustNew(2023, time.February, 24)},
+		{"1. march 2024 true", rawdate.MustNew(2024, time.March, 1), time.Friday, true, rawdate.MustNew(2024, time.March, 1)},
+		{"1. march 2024 true", rawdate.MustNew(2024, time.March, 1), time.Friday, false, rawdate.MustNew(2024, time.February, 23)},
+		{"15. april 2024 true", rawdate.MustNew(2024, time.April, 15), time.Sunday, true, rawdate.MustNew(2024, time.April, 14)},
+		{"15. april 2024 false", rawdate.MustNew(2024, time.April, 15), time.Sunday, false, rawdate.MustNew(2024, time.April, 14)},
+		{"16. april 2024 true", rawdate.MustNew(2024, time.April, 15), time.Thursday, true, rawdate.MustNew(2024, time.April, 11)},
+		{"16. april 2024 false", rawdate.MustNew(2024, time.April, 15), time.Thursday, false, rawdate.MustNew(2024, time.April, 11)},
+		{"21. april 2024 true", rawdate.MustNew(2024, time.April, 21), time.Sunday, true, rawdate.MustNew(2024, time.April, 21)},
+		{"21. april 2024 false", rawdate.MustNew(2024, time.April, 21), time.Sunday, false, rawdate.MustNew(2024, time.April, 14)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.base.PreviousWeekday(tt.weekday, tt.orToday); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("PreviousWeekday() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/rawdate/rawdate_test.go
+++ b/rawdate/rawdate_test.go
@@ -294,3 +294,47 @@ func TestRawDate_Weekday(t *testing.T) {
 		})
 	}
 }
+
+func TestRawDate_MonthStart(t *testing.T) {
+	tests := []struct {
+		name string
+		base rawdate.RawDate
+		want rawdate.RawDate
+	}{
+		{"march 2024", rawdate.MustNew(2024, time.March, 11), rawdate.MustNew(2024, time.March, 1)},
+		{"february 2024", rawdate.MustNew(2024, time.February, 13), rawdate.MustNew(2024, time.February, 1)},
+		{"february 2023", rawdate.MustNew(2023, time.February, 15), rawdate.MustNew(2023, time.February, 1)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.base.MonthStart(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MonthStart() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRawDate_MonthEnd(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields rawdate.RawDate
+		want   rawdate.RawDate
+	}{
+		{"march 2024", rawdate.MustNew(2024, time.March, 11), rawdate.MustNew(2024, time.March, 31)},
+		{"april 2024", rawdate.MustNew(2024, time.April, 11), rawdate.MustNew(2024, time.April, 30)},
+		{"february 2024", rawdate.MustNew(2024, time.February, 13), rawdate.MustNew(2024, time.February, 29)},
+		{"february 2023", rawdate.MustNew(2023, time.February, 15), rawdate.MustNew(2023, time.February, 28)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := rawdate.RawDate{
+				Year0:  tt.fields.Year0,
+				Month0: tt.fields.Month0,
+				Day0:   tt.fields.Day0,
+			}
+			if got := r.MonthEnd(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MonthEnd() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
+ `MonthEnd()`: Returns a new RawDate representing the last day of the month.
+ `MonthEnd()`: Returns a new RawDate representing the last day of the month.
+ `NextWeekday(weekday time.Weekday, orToday bool)`, the function returns the next date that falls on the specified weekday.
+ `PreviousWeekday(weekday time.Weekday, orToday bool)`, the function returns the previous date that falls on the specified weekday.
Both `NextWeekday(weekday time.Weekday, orToday bool)` and `PreviousWeekday(weekday time.Weekday, orToday bool)` return the current day if the 'orToday' parameter is set to true and the current day is the same as the specified weekday.